### PR TITLE
feat: redesign si:create with empirical validation workflow

### DIFF
--- a/docs/brainstorms/2026-04-28-si-create-redesign-requirements.md
+++ b/docs/brainstorms/2026-04-28-si-create-redesign-requirements.md
@@ -1,0 +1,70 @@
+---
+date: 2026-04-28
+topic: si-create-redesign
+---
+
+# si:create Redesign — Empirical Skill Creation
+
+## Problem Frame
+
+The current `si:create` skill is a template filler: ask for a name and purpose, write a SKILL.md, done. Skills produced this way are brittle — they codify the user's intent, not a validated workflow. The result is skills that fail silently or require repeated correction before they work reliably.
+
+The core insight: a skill codified from an empirically attempted workflow is qualitatively better than one written from description alone. Auth walls, missing dependencies, non-obvious ordering constraints — these only surface when you actually try the workflow.
+
+## Requirements
+
+- **R1.** Accept optional `$ARGUMENTS` (skill name, description, or context) upfront. Use whatever is given as a starting point; only ask for what's missing.
+- **R2.** Interview the user first — one question at a time — to capture the intended workflow in minimal, generalizable steps before attempting anything.
+- **R3.** If context or a topic is given, run a research phase to check whether sufficient documentation, prior skills, or existing patterns already exist.
+- **R4.** Classify the skill by verifiability before attempting a trial:
+  - **Verifiable** — the skill has a concrete, checkable output (SQL query returns rows, file is created, API responds). Run the full empirical trial.
+  - **Non-verifiable** — style guides, best-practice references, judgment-based workflows. The skill self-recommends the most appropriate testing approach (e.g. review by the user, forward-test with a subagent evaluator).
+- **R5.** For verifiable skills, attempt the workflow empirically — step by step — before writing any SKILL.md. The trial is the ground truth the skill is built on.
+- **R6.** During the trial, detect and document auth walls, setup steps, credential requirements, and ordering constraints. These become the skill's `setup.md` or inline prerequisites section.
+- **R7.** When the trial hits a wall it cannot resolve alone, surface it to the user with options: resolve now, skip the wall (document it), or abort.
+- **R8.** Learn from trial-and-error: the final SKILL.md must reflect what was actually discovered — including failed paths, dead ends, and the reason the surviving approach was chosen.
+- **R9.** After writing the SKILL.md, forward-test it with a fresh subagent context (subagent is given the skill and a real task; does not know it is being tested). The skill must succeed without unnecessary steps.
+- **R10.** Present a clean, progressively disclosed UI: one question at a time via `AskUserQuestion`, clear phase labels printed to chat, no walls of text.
+
+## Success Criteria
+
+- A skill created with si:create works end-to-end the first time a user invokes it on a real task.
+- Auth walls and setup steps are always documented before the skill is shipped.
+- For verifiable skills, the forward-test subagent completes the task without errors and without unnecessary steps.
+- The time from invocation to a working skill is no longer than creating one manually — the empirical phase replaces the user's own trial-and-error, not adds to it.
+
+## Scope Boundaries
+
+- si:create does not replace `si:improve`. It creates new skills from scratch; si:improve patches existing ones based on session failures.
+- The empirical trial runs in the current session context (not a new terminal). Subagents are used for forward-testing only.
+- si:create does not manage skill discovery or the global skills registry — it creates one skill at a time.
+- Non-verifiable skills still get a SKILL.md; the empirical trial phase is replaced by a self-recommended alternative (user review, pattern match against existing skills, etc.).
+
+## Key Decisions
+
+- **Interview before trial**: User describes the workflow first; trial validates and extends it. Avoids wasted effort on a dead-end trial.
+- **Verifiability gates the trial**: The skill classifies itself by whether its output can be mechanically checked. This avoids forcing expensive empirical runs on reference/knowledge skills.
+- **Ask user when trial hits a wall**: No silent fallbacks. The user decides whether to resolve the wall now, document it, or abort.
+- **Forward-test is mandatory for verifiable skills**: The skill is not shipped until a fresh subagent can complete the workflow without errors and without empty steps.
+
+## Dependencies / Assumptions
+
+- `writing-claude-skill` skill provides the authoring standard. si:create must invoke it or embed its checklist before writing SKILL.md.
+- The `AskUserQuestion` tool must be in `allowed-tools`.
+- Trial logs (what was attempted, what failed, what succeeded) should be persisted alongside the skill — either in a `trial-log.md` or embedded as a `setup.md` within the skill directory.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- None.
+
+### Deferred to Planning
+
+- [Affects R6][Technical] Where exactly are trial logs persisted? Options: `<skill-dir>/trial-log.md`, `~/.si-errors/trials/<skill-name>.json`, or embedded as a `setup.md` in the skill directory.
+- [Affects R9][Technical] How is the forward-test subagent isolated from the current session context? The subagent must not have access to the trial transcript — it should behave as a fresh user invoking the skill.
+- [Affects R4][Needs research] Is there a reliable heuristic for classifying verifiability, or does this always require asking the user?
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning

--- a/docs/brainstorms/2026-04-28-si-improve-verification-requirements.md
+++ b/docs/brainstorms/2026-04-28-si-improve-verification-requirements.md
@@ -1,0 +1,68 @@
+---
+date: 2026-04-28
+topic: si-improve-verification
+---
+
+# si:improve Verification — Session Checkpoint Replay
+
+## Problem Frame
+
+`si:improve` analyzes session failures and applies fixes to skills and CLAUDE.md files. But it never answers the only question that matters: did the fix actually work? Without a verification step, si:improve is compounding analysis, not compounding knowledge. Fixes that don't work still get baked into the harness, creating false confidence.
+
+The solution is a feedback loop: after applying a fix, replay from the exact point of failure in a fresh subagent context — with the improvement in place — and verify that the workflow now completes without errors and without unnecessary steps.
+
+## Requirements
+
+- **R1.** After si:improve applies a change (Step 5), it calls `si:verify` with a checkpoint: the session ID and the message index at which the user originally invoked the failing skill or workflow.
+- **R2.** `si:verify` is a new, standalone skill — separate from si:improve — that can also be invoked directly by the user to replay any saved checkpoint.
+- **R3.** A checkpoint contains exactly: session ID + message index. The session JSONL already captures everything else (failing tool call, error output, surrounding context).
+- **R4.** `si:verify` reads the session JSONL up to the checkpoint message index and injects that context into a subagent. The subagent does not re-run si:errors; it operates directly on the session context.
+- **R5.** The subagent attempts the same workflow from the checkpoint. It has access to the updated skill/CLAUDE.md (the improvement is already written to disk).
+- **R6.** Verification succeeds when: (a) the action completes without errors, and (b) no unnecessary or empty steps are taken — the workflow is the shortest path to the intended outcome.
+- **R7.** si:improve reports the verification result in its Step 6 summary: `Verified: yes / no / skipped` per applied change.
+- **R8.** Checkpoints are saved alongside the si:errors log at `~/.si-errors/<session-id>-checkpoints.json` so they can be replayed independently.
+- **R9.** si:verify does not alter the current session or any existing files. It is purely a read + subagent operation.
+
+## Success Criteria
+
+- After running si:improve, the user knows with confidence whether each applied fix actually works — without having to manually reproduce the failure.
+- si:verify can be invoked standalone (`/si:verify <session-id> <message-index>`) to replay any checkpoint at any time.
+- Verification adds no unnecessary ceremony: if a fix is unverifiable (e.g. a style guide addition with no checkable output), si:verify reports `skipped` with a reason rather than blocking.
+
+## Scope Boundaries
+
+- `si:verify` runs as an in-process subagent, not a new terminal or CLI session. Spawning a real new terminal is out of scope.
+- Workspace file state (git snapshot) is out of scope for this ticket. Verification assumes the workspace hasn't diverged significantly from the failure point; if it has, the subagent will surface that as a gap.
+- `si:verify` does not re-run `si:errors` extraction — that is si:improve's responsibility.
+- Loop-back (auto-retry with a new fix if verification fails) is out of scope. si:improve reports the failure; the user decides whether to run si:improve again.
+- si:verify does not evaluate subjective or non-verifiable improvements (style, wording changes). It reports `skipped` for these.
+
+## Key Decisions
+
+- **Separate si:verify skill**: Atomically testable, invocable standalone, clean separation from si:improve's analysis logic.
+- **Checkpoint = session ID + message index only**: The session JSONL is the source of truth for everything else. Storing redundant data in the checkpoint creates drift.
+- **Subagent, not new terminal**: Simpler to orchestrate, observable within the current session, easier to verify that the test itself is correct.
+- **Success = no errors + shortest path**: Mechanical correctness (no errors) is necessary but not sufficient. A workflow with unnecessary steps indicates the improvement is incomplete.
+
+## Dependencies / Assumptions
+
+- `resume-claude-session` skill already exists and reads `~/.claude/projects/**/<sessionId>.jsonl`. si:verify can reuse or mirror this pattern for context injection.
+- The session JSONL format is stable and contains enough context to reconstruct the failure scenario without re-running si:errors.
+- si:improve must be updated to: (a) record a checkpoint when it identifies a failure, and (b) call si:verify after Step 5.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- None.
+
+### Deferred to Planning
+
+- [Affects R4][Technical] How exactly is session JSONL context injected into the subagent? Options: pass the raw JSONL slice as context, synthesize a compact prompt from the relevant turns, or use the Agent tool with a pre-built context string.
+- [Affects R1][Technical] At what point in si:improve's Step 2 (failure analysis) is the checkpoint message index determined? It should be the index of the turn where the user invoked the failing skill — needs to be extracted reliably from the JSONL.
+- [Affects R6][Needs research] How does the subagent know what "shortest path" means for the specific workflow? Does si:verify receive the expected steps from si:improve, or does it infer from the session context?
+- [Affects R9][Technical] Checkpoint file format: JSON array of `{sessionId, messageIndex, failureDescription, appliedFix}` entries, written to `~/.si-errors/<session-id>-checkpoints.json`.
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning

--- a/skills/si:create/SKILL.md
+++ b/skills/si:create/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: si:create
+description: Create a skill empirically: interview, trial, auth-wall detection, then codify what worked. Use when adding to ~/.claude/skills/.
+argument-hint: "[optional: skill name, description, or topic]"
+disable-model-invocation: true
+allowed-tools: AskUserQuestion, Bash, Read, Write, Grep, Glob, Agent
+---
+
+# Create Skill
+
+Create a new personal Claude Code skill in `~/.claude/skills/` by empirically validating the workflow before codifying it. Interview first, attempt second, write third.
+
+## Step 1: Resolve config root
+
+```bash
+CLAUDE_ROOT=$(readlink -f ~/.claude 2>/dev/null || realpath ~/.claude 2>/dev/null || echo "$HOME/.claude")
+SKILLS_DIR="$CLAUDE_ROOT/skills"
+echo "Skills dir: $SKILLS_DIR"
+```
+
+Use the resolved `CLAUDE_ROOT` for all file operations throughout this skill.
+
+## Step 2: Intake
+
+Read `$ARGUMENTS`. Extract any skill name, description, or topic provided.
+
+Print to chat:
+```
+Context from arguments: <what was extracted, or "none">
+```
+
+## Step 3: Research (if context given)
+
+If context was extracted in Step 2, before interviewing:
+
+1. List existing skills to check for overlap:
+   ```bash
+   ls "$SKILLS_DIR"
+   ```
+2. If any existing skill name looks related, read its SKILL.md briefly.
+3. Note overlap or gaps.
+
+Print one line: `"Found similar: X"` or `"No existing skill covers this."` Then continue.
+
+## Step 4: Interview
+
+Use `AskUserQuestion` — one call per question. Skip questions already answered by `$ARGUMENTS`.
+
+Ask in order:
+
+1. **Purpose**: "What should this skill do, and what would make you invoke it?"
+2. **Name**: "What's a good short name? (lowercase, hyphens only — e.g. `process-invoices`)"
+3. **Verifiability**: "Does this skill produce a concrete, checkable result — something you can verify worked? For example: a file is created, a query returns rows, an API responds successfully."
+
+Hold answers in memory for all remaining steps.
+
+## Step 5: Classify and plan
+
+Based on the interview answers:
+
+**Verifiable** — the skill has a concrete, checkable output:
+→ Proceed to Step 6 (empirical trial).
+
+**Non-verifiable** — style guide, best-practice reference, judgment-based workflow:
+→ Skip Step 6. Note in the SKILL.md body which testing approach fits best:
+  - Forward-test with a subagent evaluator (agent attempts the task, output is reviewed for quality)
+  - User review after first use
+
+Print to chat:
+```
+Skill type:  verifiable / non-verifiable
+Trial:       will run / skipping (<reason>)
+```
+
+## Step 6: Empirical trial (verifiable skills only)
+
+Attempt the workflow step by step to discover what actually works — including auth walls, ordering constraints, and non-obvious dependencies.
+
+### Protocol
+
+For each step in the workflow:
+1. Attempt it with Bash or the appropriate tool.
+2. Record the outcome: success, error, or wall.
+3. If it fails with a resolvable error (wrong flag, missing package), fix it and retry.
+4. If an auth wall or external blocker is hit, stop and ask the user:
+
+```
+AskUserQuestion: "The trial hit a wall at step N: [describe wall]
+How should I proceed?
+A) Resolve it now — tell me what to do
+B) Document it as a setup prerequisite and continue past it
+C) Abort — this skill isn't ready to be created yet"
+```
+
+### Trial log
+
+Maintain a running log in memory:
+
+| Step | Action | Outcome | Notes |
+|------|--------|---------|-------|
+| 1 | … | success / error / wall | … |
+
+Print the completed trial log to chat before continuing.
+
+### Outcome
+
+- **All steps succeeded**: Proceed to Step 7.
+- **Some walls documented (user chose B)**: Proceed to Step 7; walls become `setup.md`.
+- **Aborted (user chose C)**: Stop. Print what was learned. Do not create a skill.
+
+## Step 7: Read authoring standard
+
+Before writing anything, read:
+```bash
+cat "$SKILLS_DIR/writing-claude-skill/SKILL.md"
+```
+
+Apply its audit checklist when writing the skill in Step 8.
+
+## Step 8: Write the skill
+
+### Create directory
+
+```bash
+mkdir -p "$SKILLS_DIR/<name>"
+```
+
+### Write SKILL.md
+
+Create `$SKILLS_DIR/<name>/SKILL.md` using:
+- **Frontmatter**:
+  - `name`: the chosen slug
+  - `description`: under 130 chars, third person, front-load trigger keywords, include both what and when
+  - `disable-model-invocation: true` (change to `false` only if user confirmed auto-invoke is wanted)
+  - `allowed-tools`: list only tools the skill actually needs
+- **Body** (imperative form):
+  - Steps in the empirically proven order
+  - Trial-discovered prerequisites before step 1
+  - Failed approaches omitted — keep only what worked
+  - Under 500 lines
+
+### Create setup.md (if walls were hit)
+
+If the trial uncovered auth walls or required setup steps, create `$SKILLS_DIR/<name>/setup.md`:
+- One section per wall: what it is, exact steps to resolve, credentials or URLs needed
+- Reference it from SKILL.md: `"Complete [setup.md](setup.md) before first use."`
+
+## Step 9: Forward-test (verifiable skills only)
+
+Launch an isolated subagent to validate the skill from a fresh context:
+
+```
+Agent(
+  description: "Forward-test: <skill-name>",
+  prompt: "Use the skill file at <SKILLS_DIR>/<name>/SKILL.md to <concrete task that matches what the skill does>.
+
+Report what you did step by step and whether it worked."
+)
+```
+
+Do not tell the subagent it is being tested. Do not give it the expected output.
+
+Evaluate the result:
+- **Pass**: Task completed without errors. No unnecessary or empty steps. Workflow is the shortest path to the result.
+- **Fail**: Errors occurred, steps were skipped, or output was incomplete. Update SKILL.md to fix the gap. Re-test once.
+
+Print:
+```
+Forward-test: pass / fail / skipped (non-verifiable)
+Reason: <one line>
+```
+
+## Step 10: Report
+
+Print to chat:
+
+```
+Skill created: ~/.claude/skills/<name>/SKILL.md
+Setup docs:   ~/.claude/skills/<name>/setup.md  (if applicable)
+
+Trial:         <N steps attempted, M walls documented>  (or "skipped — non-verifiable")
+Forward-test:  pass / fail / skipped
+
+Invoke with:  /<name>
+```
+
+Show the full SKILL.md content so the user can verify it looks right.

--- a/skills/si:improve/SKILL.md
+++ b/skills/si:improve/SKILL.md
@@ -67,9 +67,11 @@ For each friction event worth compounding, extract:
 
 Print the findings to the chat before proceeding:
 
-| # | What happened | Root cause | What would have prevented it | Worth improving? |
-|---|---------------|------------|------------------------------|-----------------|
-| 1 | …             | …          | …                            | Yes / No        |
+| # | Line | What happened | Root cause | What would have prevented it | Worth improving? |
+|---|------|---------------|------------|------------------------------|-----------------|
+| 1 | N    | …             | …          | …                            | Yes / No        |
+
+**Line**: the `line` field from the error event in the si:errors JSON. This is the JSONL line number used as the checkpoint index when calling si:verify after changes are applied.
 
 **Worth improving?** rubric:
 - **Yes** — repeated pattern, cost meaningful time, or caused the user to steer/correct course
@@ -145,6 +147,53 @@ For each approved change, read the target file and apply the minimal surgical ed
 
 When the approved change introduces a new workflow skill, check both the global and project CLAUDE.md (if it exists) for a `## Custom skills @self-improve` section. Add the one-line invocation rule to whichever is most appropriate — project CLAUDE.md if the skill is project-specific, global otherwise. Create the section at the bottom of the target file if it doesn't exist.
 
+## Step 5b: Record checkpoints and verify
+
+For each change applied in Step 5, record a checkpoint and verify the fix.
+
+**Write the checkpoint** to `~/.si-errors/<session-id>-checkpoints.json`:
+
+```bash
+python3 - <<PYEOF
+import json, os
+from datetime import datetime, timezone
+
+SESSION_ID = "$SESSION_ID"
+LINE_NUMBER = LINE_FROM_TABLE  # the Line column value for this finding
+FIX_DESC = "one-line description of the applied fix"
+
+path = os.path.expanduser(f"~/.si-errors/{SESSION_ID}-checkpoints.json")
+existing = []
+if os.path.exists(path):
+    with open(path) as f:
+        try:
+            existing = json.load(f)
+        except Exception:
+            pass
+
+existing.append({
+    "sessionId": SESSION_ID,
+    "messageIndex": LINE_NUMBER,
+    "appliedFix": FIX_DESC,
+    "recordedAt": datetime.now(timezone.utc).isoformat(),
+})
+
+with open(path, "w") as f:
+    json.dump(existing, f, indent=2)
+print(f"Checkpoint saved: {path}")
+PYEOF
+```
+
+**Run si:verify** for each checkpoint:
+
+```
+/si:verify <session-id> <line-number>
+```
+
+Hold the result (`pass / fail / skipped`) in memory for Step 6. Run checkpoints sequentially — one si:verify call per applied change.
+
+**Skip verification** for non-verifiable fixes (style changes, wording tweaks). Record `skipped: non-verifiable` for those in Step 6.
+
 ## Step 6: Report
 
 Print a summary to the chat:
@@ -153,7 +202,7 @@ Print a summary to the chat:
 Self-Improve Complete
 
 Applied:
-  - [file]: [one-line description of change]
+  - [file]: [one-line description of change]  [Verified: pass / fail / skipped]
 
 Skipped:
   - [failure]: [reason]
@@ -163,6 +212,9 @@ Existing skills improved:   N
 Global CLAUDE.md improved:  N
 Local CLAUDE.md improved:   N
 New skills created:         N
+Verified pass:              N
+Verified fail:              N
+Verified skipped:           N
 ```
 
 ## Rules

--- a/skills/si:verify/SKILL.md
+++ b/skills/si:verify/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: si:verify
+description: Verify a si:improve fix by replaying from the failure checkpoint in a fresh subagent. Reports pass/fail without touching the current session. Use after si:improve applies changes, or standalone with a session ID and message index.
+argument-hint: "<session-id> <message-index>"
+disable-model-invocation: true
+allowed-tools: Bash, Read, Agent
+---
+
+# SI Verify
+
+Replay a session from a specific failure point in an isolated subagent — with the si:improve fix already on disk — and verify the workflow now completes correctly.
+
+> **Status: stub — full implementation tracked in issue #2.**
+> The interface below is stable. Step 4 (subagent injection) is the open implementation question.
+
+## Interface
+
+Called by `si:improve` after Step 5 (Apply Changes):
+```
+/si:verify <session-id> <message-index>
+```
+
+Or standalone by the user to replay any saved checkpoint:
+```
+/si:verify <session-id> <message-index>
+```
+
+## Step 1: Load inputs
+
+Parse `$ARGUMENTS`:
+```
+SESSION_ID = $ARGUMENTS[0]
+MESSAGE_INDEX = $ARGUMENTS[1]
+```
+
+If either is missing, check `~/.si-errors/$SESSION_ID-checkpoints.json` for the most recent checkpoint for this session.
+
+If still missing, stop and ask the user for both values.
+
+## Step 2: Locate session JSONL
+
+```bash
+SESSION_JSONL=$(find ~/.claude/projects -name "${SESSION_ID}.jsonl" 2>/dev/null | head -1)
+echo "Session transcript: $SESSION_JSONL"
+```
+
+If not found, stop and report: `"Session JSONL not found for $SESSION_ID"`.
+
+## Step 3: Extract context up to checkpoint
+
+Read the session JSONL and extract all messages up to and including `MESSAGE_INDEX`. This is the context the subagent needs to understand what it was trying to do.
+
+Do not run `si:errors` — the session JSONL is sufficient.
+
+## Step 4: Launch replay subagent
+
+Spawn an Agent with the extracted session context injected as background. The subagent should not know it is being tested.
+
+The subagent's task: attempt the same workflow that failed at `MESSAGE_INDEX`, using whatever skills or CLAUDE.md rules are currently on disk (the fix has already been applied).
+
+> **[Implementation note]**: The exact mechanism for injecting JSONL context into the Agent prompt without leaking the current session is the key open question for issue #2. Options: pass a synthesized summary of the relevant turns, or pass the raw JSONL slice as a context block.
+
+## Step 5: Evaluate result
+
+Verification **passes** when:
+- The action completes without errors.
+- No unnecessary or empty steps are taken — the workflow is the shortest path to the intended outcome.
+
+Verification **fails** when:
+- An error occurs.
+- The subagent gets stuck, loops, or takes roundabout steps.
+- The output is incomplete.
+
+Verification is **skipped** when:
+- The applied fix was to a non-verifiable improvement (style, wording). Report `skipped: non-verifiable change`.
+
+## Step 6: Report
+
+Print the result so `si:improve` can include it in its Step 6 summary:
+
+```
+si:verify result
+  Session:       <session-id>
+  Checkpoint:    message <index>
+  Outcome:       pass / fail / skipped
+  Reason:        <one line>
+```
+
+Save the checkpoint record to `~/.si-errors/<session-id>-checkpoints.json`:
+
+```json
+{
+  "sessionId": "<session-id>",
+  "messageIndex": <index>,
+  "verifiedAt": "<ISO timestamp>",
+  "outcome": "pass | fail | skipped",
+  "reason": "<one line>"
+}
+```

--- a/skills/si:verify/SKILL.md
+++ b/skills/si:verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: si:verify
-description: Verify a si:improve fix by replaying from the failure checkpoint in a fresh subagent. Reports pass/fail without touching the current session. Use after si:improve applies changes, or standalone with a session ID and message index.
+description: Verify a si:improve fix by replaying from the failure checkpoint in a fresh subagent. Reports pass/fail without touching the current session. Use after si:improve, or standalone with a session ID and message index.
 argument-hint: "<session-id> <message-index>"
 disable-model-invocation: true
 allowed-tools: Bash, Read, Agent
@@ -8,92 +8,172 @@ allowed-tools: Bash, Read, Agent
 
 # SI Verify
 
-Replay a session from a specific failure point in an isolated subagent — with the si:improve fix already on disk — and verify the workflow now completes correctly.
-
-> **Status: stub — full implementation tracked in issue #2.**
-> The interface below is stable. Step 4 (subagent injection) is the open implementation question.
-
-## Interface
-
-Called by `si:improve` after Step 5 (Apply Changes):
-```
-/si:verify <session-id> <message-index>
-```
-
-Or standalone by the user to replay any saved checkpoint:
-```
-/si:verify <session-id> <message-index>
-```
+Replay a session failure point in an isolated subagent — with the si:improve fix already on disk — and verify the workflow now completes correctly.
 
 ## Step 1: Load inputs
 
 Parse `$ARGUMENTS`:
-```
-SESSION_ID = $ARGUMENTS[0]
-MESSAGE_INDEX = $ARGUMENTS[1]
+
+```bash
+SESSION_ID=$(echo "$ARGUMENTS" | awk '{print $1}')
+MESSAGE_INDEX=$(echo "$ARGUMENTS" | awk '{print $2}')
+echo "Session: $SESSION_ID"
+echo "Checkpoint: message $MESSAGE_INDEX"
 ```
 
-If either is missing, check `~/.si-errors/$SESSION_ID-checkpoints.json` for the most recent checkpoint for this session.
+If `SESSION_ID` is empty, stop and ask the user for `<session-id> <message-index>`.
 
-If still missing, stop and ask the user for both values.
+If `MESSAGE_INDEX` is empty, check `~/.si-errors/${SESSION_ID}-checkpoints.json` for the most recent entry and use its `messageIndex`. If still missing, stop and report.
 
 ## Step 2: Locate session JSONL
 
 ```bash
 SESSION_JSONL=$(find ~/.claude/projects -name "${SESSION_ID}.jsonl" 2>/dev/null | head -1)
-echo "Session transcript: $SESSION_JSONL"
+if [ -z "$SESSION_JSONL" ]; then
+  echo "ERROR: Session JSONL not found for $SESSION_ID"
+  exit 1
+fi
+echo "Transcript: $SESSION_JSONL"
 ```
 
-If not found, stop and report: `"Session JSONL not found for $SESSION_ID"`.
+## Step 3: Extract conversation context
 
-## Step 3: Extract context up to checkpoint
+Read the JSONL up to `MESSAGE_INDEX` and extract the last 30 meaningful turns:
 
-Read the session JSONL and extract all messages up to and including `MESSAGE_INDEX`. This is the context the subagent needs to understand what it was trying to do.
+```bash
+python3 - <<PYEOF
+import json, sys
 
-Do not run `si:errors` — the session JSONL is sufficient.
+jsonl_path = "$SESSION_JSONL"
+stop_at = $MESSAGE_INDEX
+
+lines = []
+with open(jsonl_path) as f:
+    for i, line in enumerate(f):
+        if i > stop_at:
+            break
+        try:
+            lines.append(json.loads(line.strip()))
+        except Exception:
+            pass
+
+turns = []
+for obj in lines[-30:]:
+    t = obj.get("type")
+    if t == "user":
+        msg = obj.get("message", {})
+        content = msg.get("content", "") if isinstance(msg, dict) else ""
+        if isinstance(content, str) and content.strip():
+            text = content.strip()
+            if not text.startswith("<command-") and not text.startswith("Base directory"):
+                turns.append({"role": "user", "text": text[:600]})
+        elif isinstance(content, list):
+            for c in content:
+                if isinstance(c, dict) and c.get("type") == "text":
+                    text = c.get("text", "").strip()
+                    if text and not text.startswith("<command-") and not text.startswith("Base directory"):
+                        turns.append({"role": "user", "text": text[:600]})
+    elif t == "assistant":
+        msg = obj.get("message", {})
+        content = msg.get("content", []) if isinstance(msg, dict) else []
+        if isinstance(content, list):
+            for c in content:
+                if isinstance(c, dict) and c.get("type") == "text" and c.get("text", "").strip():
+                    turns.append({"role": "assistant", "text": c["text"].strip()[:600]})
+                    break
+
+print(json.dumps(turns, indent=2))
+PYEOF
+```
+
+From the extracted turns, synthesize three things in memory:
+1. **User intent** — what was the user trying to accomplish?
+2. **Failure** — what went wrong? (last error or friction before the checkpoint)
+3. **Workflow** — what skill, command, or step was being attempted?
+
+If the context is too sparse to synthesize these, report `skipped: insufficient context at checkpoint` and stop.
 
 ## Step 4: Launch replay subagent
 
-Spawn an Agent with the extracted session context injected as background. The subagent should not know it is being tested.
+Build a prompt using the synthesized context. Do not pass raw JSONL, the current session, or any hint that this is a test.
 
-The subagent's task: attempt the same workflow that failed at `MESSAGE_INDEX`, using whatever skills or CLAUDE.md rules are currently on disk (the fix has already been applied).
+```
+Agent(
+  description: "Verify: <workflow>",
+  prompt: "Prior context: A user was working on the following task.
 
-> **[Implementation note]**: The exact mechanism for injecting JSONL context into the Agent prompt without leaking the current session is the key open question for issue #2. Options: pass a synthesized summary of the relevant turns, or pass the raw JSONL slice as a context block.
+<paste the last 5-8 user turns as a brief narrative, e.g.:
+  'The user wanted to [intent]. They ran /some-skill and encountered [failure description].'
+>
+
+A fix has since been applied. Your task: attempt the same workflow now and report whether it works.
+
+Task: <restate the user intent as a concrete action>
+
+Report each step you take. If it succeeds, say so clearly. If it fails, describe the error."
+)
+```
+
+The subagent has full access to all skills and CLAUDE.md on disk. The fix is already in place — do not apply anything yourself.
 
 ## Step 5: Evaluate result
 
-Verification **passes** when:
-- The action completes without errors.
-- No unnecessary or empty steps are taken — the workflow is the shortest path to the intended outcome.
+Review the subagent's report:
 
-Verification **fails** when:
-- An error occurs.
-- The subagent gets stuck, loops, or takes roundabout steps.
-- The output is incomplete.
+**Pass** — all of:
+- The action completed without errors.
+- No unnecessary or empty steps (not retrying things that should work, not asking for already-known info).
+- The workflow is the shortest path to the outcome.
 
-Verification is **skipped** when:
-- The applied fix was to a non-verifiable improvement (style, wording). Report `skipped: non-verifiable change`.
+**Fail** — any of:
+- An error occurred.
+- The subagent got stuck, looped, or took roundabout steps.
+- The output was incomplete or incorrect.
 
-## Step 6: Report
+**Skipped** — when:
+- Context was too sparse to synthesize a meaningful replay prompt.
+- The applied fix was non-verifiable (style change, wording tweak with no checkable output).
 
-Print the result so `si:improve` can include it in its Step 6 summary:
+## Step 6: Save checkpoint and report
+
+Save the result to `~/.si-errors/${SESSION_ID}-checkpoints.json`:
+
+```bash
+python3 - <<PYEOF
+import json, os
+from datetime import datetime, timezone
+
+path = os.path.expanduser(f"~/.si-errors/$SESSION_ID-checkpoints.json")
+existing = []
+if os.path.exists(path):
+    with open(path) as f:
+        try:
+            existing = json.load(f)
+        except Exception:
+            existing = []
+
+existing.append({
+    "sessionId": "$SESSION_ID",
+    "messageIndex": $MESSAGE_INDEX,
+    "verifiedAt": datetime.now(timezone.utc).isoformat(),
+    "outcome": "OUTCOME_PLACEHOLDER",
+    "reason": "REASON_PLACEHOLDER"
+})
+
+with open(path, "w") as f:
+    json.dump(existing, f, indent=2)
+print(f"Checkpoint saved: {path}")
+PYEOF
+```
+
+Replace `OUTCOME_PLACEHOLDER` and `REASON_PLACEHOLDER` with the actual outcome and reason before writing.
+
+Print the final result so `si:improve` can include it in its Step 6 summary:
 
 ```
 si:verify result
-  Session:       <session-id>
-  Checkpoint:    message <index>
-  Outcome:       pass / fail / skipped
-  Reason:        <one line>
-```
-
-Save the checkpoint record to `~/.si-errors/<session-id>-checkpoints.json`:
-
-```json
-{
-  "sessionId": "<session-id>",
-  "messageIndex": <index>,
-  "verifiedAt": "<ISO timestamp>",
-  "outcome": "pass | fail | skipped",
-  "reason": "<one line>"
-}
+  Session:    <session-id>
+  Checkpoint: message <index>
+  Outcome:    pass / fail / skipped
+  Reason:     <one line>
 ```


### PR DESCRIPTION
## Summary

- **si:create** — fully redesigned with empirical validation workflow
- **si:verify** — new skill: full JSONL checkpoint replay and fix verification
- **si:improve** — wired to call si:verify after applying each fix
- Requirements docs added to `docs/brainstorms/`

Refs #1, #2

---

## Commit 1: si:create redesign + si:verify stub

### `skills/si:create/SKILL.md` (full rewrite)

The old skill was a template filler. The redesign adds an empirical validation loop:

1. **Intake** — reads \`\$ARGUMENTS\` for any context
2. **Research** — checks for existing overlapping skills first
3. **Interview** — one \`AskUserQuestion\` at a time: purpose → name → verifiability
4. **Classify** — verifiable skills get a trial; non-verifiable skills self-recommend a testing approach
5. **Empirical trial** — attempts the workflow step by step; surfaces auth walls (resolve / document / abort)
6. **Write** — SKILL.md and optional \`setup.md\` for auth walls, following \`writing-claude-skill\` standards
7. **Forward-test** — isolated subagent given the skill + a real task; must complete without errors and without unnecessary steps

### `skills/si:verify/SKILL.md` (stub, then fully implemented in commit 2)

Stable interface: \`/si:verify <session-id> <message-index>\`

---

## Commit 2: si:verify implementation + si:improve wiring

### `skills/si:verify/SKILL.md` (stub → full implementation)

**Step 3**: Python snippet reads JSONL up to \`MESSAGE_INDEX\`, parses last 30 meaningful turns, synthesizes user intent + failure description.

**Step 4**: Launches isolated Agent subagent with synthesized context (not raw JSONL, not current session) to replay the failed workflow with the fix already on disk.

**Step 5**: Pass = no errors + shortest path. Fail = any error/stuck/loop. Skipped = sparse context or non-verifiable fix.

**Step 6**: Saves checkpoint to \`~/.si-errors/<session-id>-checkpoints.json\`. Replayable standalone at any time.

### `skills/si:improve/SKILL.md` (three surgical additions)

- **Step 2d table** gains a \`Line\` column — sourced from \`line\` field already in si:errors JSON, used as checkpoint index
- **Step 5b** — after applying each change, writes checkpoint and calls \`/si:verify\`; non-verifiable fixes record \`skipped\`
- **Step 6 report** — each change shows \`[Verified: pass / fail / skipped]\` inline; three new summary counters added

## Design decisions

- Subagent context injection uses synthesis (not raw JSONL) to prevent current session leaking into replay
- \`line\` field in si:errors JSON was already there — no script changes needed
- si:verify is fully standalone: works without si:improve if session-id + message-index are provided
- No loop-back on failure (out of scope): si:improve reports the result, user decides whether to re-run

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: all changes are confined to skill files; no runtime services, APIs, or databases are affected.