### PR TITLE
feat: add si:improve CTA to setup report, simplify si:create auto-invoke flow

### DIFF
--- a/skills/si:create/SKILL.md
+++ b/skills/si:create/SKILL.md
@@ -20,22 +20,6 @@ echo "Skills dir: $SKILLS_DIR"
 
 Use the resolved `CLAUDE_ROOT` for all file operations throughout this skill.
 
-## Step 1b: Load preferences
-
-```bash
-python3 -c "
-import json, os
-path = os.path.expanduser('~/.claude/si-preferences.json')
-if os.path.exists(path):
-    d = json.load(open(path))
-    print('auto_invoke=' + str(d.get('auto_invoke', '')))
-else:
-    print('auto_invoke=')
-"
-```
-
-Read the printed `auto_invoke` value and hold it in memory. Empty means unset — prompt user to run `/si:setup` first.
-
 ## Step 2: Intake
 
 Read `$ARGUMENTS`. Extract any skill name, description, or topic provided.
@@ -67,22 +51,9 @@ Ask in order:
 1. **Purpose**: "What should this skill do, and what would make you invoke it?"
 2. **Name**: "What's a good short name? (lowercase, hyphens only — e.g. `process-invoices`)"
 3. **Verifiability**: "Does this skill produce a concrete, checkable result — something you can verify worked? For example: a file is created, a query returns rows, an API responds successfully."
-4. **Auto-invoke** (only if `auto_invoke` from Step 1b is empty): "Should Claude automatically add this skill as a trigger rule in CLAUDE.md so it self-invokes when conditions match — without you typing the command? (yes / no / always yes for all future skills / always no for all future skills)"
+4. **Auto-invoke**: "Should Claude automatically add this skill as a trigger rule in CLAUDE-si.md so it self-invokes when conditions match — without you typing the command? (yes / no)"
 
-   If the user answers "always yes" or "always no", save the preference:
-
-   ```bash
-   python3 -c "
-   import json, os
-   path = os.path.expanduser('~/.claude/si-preferences.json')
-   prefs = json.load(open(path)) if os.path.exists(path) else {}
-   prefs['auto_invoke'] = True  # set False for 'always no'
-   json.dump(prefs, open(path, 'w'), indent=2)
-   print('Saved auto_invoke=' + str(prefs['auto_invoke']))
-   "
-   ```
-
-   Hold the resolved value (`true` or `false`) in memory as `auto_invoke` for Step 8. Treat "yes" and "always yes" as `true`; "no" and "always no" as `false`.
+   Hold the resolved value (`true` or `false`) in memory as `auto_invoke` for Step 8.
 
 Hold all interview answers in memory for all remaining steps.
 

--- a/skills/si:setup/SKILL.md
+++ b/skills/si:setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: si:setup
-description: Set up or reconfigure the self-improve plugin. Detects Claude root, wires CLAUDE-si.md import, and collects skill preferences. Run once after install or to reconfigure.
+description: Set up or reconfigure the self-improve plugin. Detects Claude root and wires CLAUDE-si.md import into CLAUDE.md. Run once after install or to reconfigure.
 disable-model-invocation: true
 allowed-tools: AskUserQuestion, Bash, Read, Write
 ---
@@ -8,6 +8,42 @@ allowed-tools: AskUserQuestion, Bash, Read, Write
 # Self-Improve Setup
 
 Initialize or reconfigure the self-improve plugin. Safe to re-run — all steps are idempotent.
+
+## Step 0: Reset check
+
+Detect whether setup has already been run by checking if the SI import block is present in CLAUDE.md:
+
+```bash
+python3 -c "
+import os
+claude_md = os.path.expanduser('~/.claude/CLAUDE.md')
+try:
+    content = open(claude_md).read()
+    print('configured' if '<!-- SI:IMPORT:START -->' in content else 'fresh')
+except FileNotFoundError:
+    print('fresh')
+"
+```
+
+If the output is `configured`, use `AskUserQuestion` to ask:
+
+> "Self-improve is already configured. What would you like to do?
+>
+> (1) Re-run / modify settings
+> (2) Reset — removes all si:setup state (si-preferences.json, CLAUDE-si.md, SI import from CLAUDE.md)"
+
+If the user chooses **reset**, run:
+
+```bash
+MAIN_REPO=$(git worktree list | head -1 | awk '{print $1}')
+python3 "$MAIN_REPO/skills/si:setup/scripts/reset.py"
+```
+
+Then stop — print "Reset complete. Run /si:setup again to reconfigure." and exit.
+
+If the user chooses **re-run / modify**, continue to Step 1.
+
+If the output is `fresh`, proceed directly to Step 1 without asking.
 
 ## Step 1: Detect Claude root
 
@@ -19,6 +55,8 @@ echo "Skills dir: $SKILLS_DIR"
 ```
 
 Hold `CLAUDE_ROOT` in memory.
+
+Print to chat: `✅ Claude root: <resolved path>`
 
 ## Step 2: Create CLAUDE-si.md
 
@@ -54,55 +92,23 @@ else:
 "
 ```
 
-## Step 4: Collect preferences
+After each of Steps 2 and 3, print a one-line status to chat immediately after the bash command completes:
+- Step 2 success: `✅ CLAUDE-si.md created` or `✅ CLAUDE-si.md already exists`
+- Step 2 failure: `❌ CLAUDE-si.md: <error>`
+- Step 3 success: `✅ CLAUDE.md import wired` or `✅ CLAUDE.md import already present`
+- Step 3 failure: `❌ CLAUDE.md import: <error>`
 
-Check current `auto_invoke` preference:
-
-```bash
-python3 -c "
-import json, os
-path = os.path.expanduser('~/.claude/si-preferences.json')
-if os.path.exists(path):
-    d = json.load(open(path))
-    print('current auto_invoke=' + str(d.get('auto_invoke', 'unset')))
-else:
-    print('current auto_invoke=unset')
-"
-```
-
-Use `AskUserQuestion` to ask:
-
-> "Should Claude automatically add new skills as trigger rules in CLAUDE-si.md so they self-invoke when conditions match — without you typing the command?
->
-> Current setting: `<value from above, or 'not set'>`
->
-> (yes / no)"
-
-Save the answer:
-
-```bash
-python3 -c "
-import json, os
-path = os.path.expanduser('~/.claude/si-preferences.json')
-prefs = json.load(open(path)) if os.path.exists(path) else {}
-prefs['auto_invoke'] = True  # set False for 'no'
-with open(path, 'w') as f:
-    json.dump(prefs, f, indent=2)
-print('Saved auto_invoke=' + str(prefs['auto_invoke']))
-"
-```
-
-## Step 5: Report
+## Step 4: Report
 
 Print to chat:
 
 ```
 Self-Improve Setup Complete
 
-Claude root:     <resolved path>
-CLAUDE-si.md:    ~/.claude/CLAUDE-si.md  (created / already existed)
+Claude root:      <resolved path>
+CLAUDE-si.md:     ~/.claude/CLAUDE-si.md  (created / already existed)
 CLAUDE.md import: wired / already present
-auto_invoke:     true / false
 
 Run /si:create to create your first skill.
+Run /si:improve at the end of any session to improve your agent harness — refine your existing skills and suggest new ones.
 ```


### PR DESCRIPTION
## Summary
- Adds `/si:improve` CTA to the si:setup completion report so users know to run it at end of sessions
- Simplifies si:create auto-invoke question (removes persistent preference storage, asks per-skill instead)